### PR TITLE
added stepwise image downsampling to improve the resulting image quality

### DIFF
--- a/public/javascripts/imageupload.js
+++ b/public/javascripts/imageupload.js
@@ -27,8 +27,10 @@ angular.module('imageupload', [])
 
             var canvas = getResizeArea();
 
-            var height = origImage.height;
-            var width = origImage.width;
+            var oheight = origImage.height;
+            var owidth = origImage.width;
+            var height = oheight;
+            var width = owidth;
 
             // calculate the width and height, constraining the proportions
             if (width > height) {
@@ -43,12 +45,27 @@ angular.module('imageupload', [])
                 }
             }
 
+            var img = origImage;
+            // introduce downsampling steps if appropriate
+            if(oheight / height > 2) {
+                img = document.createElement('canvas');
+                var tctx = img.getContext("2d");	
+                img.width = owidth;
+                img.height = oheight;
+                tctx.drawImage(origImage, 0, 0, owidth, oheight, 0, 0, owidth/2, oheight/2);
+                oheight /= 2; owidth /= 2;
+                while(oheight / height > 2) {
+                    tctx.drawImage(img, 0, 0, owidth, oheight, 0, 0, owidth/2, oheight/2);
+                    oheight /= 2; owidth /= 2;
+                }
+            }
+
             canvas.width = width;
             canvas.height = height;
 
             //draw image on canvas
             var ctx = canvas.getContext("2d");
-            ctx.drawImage(origImage, 0, 0, width, height);
+            ctx.drawImage(img, 0, 0, owidth, oheight, 0, 0, width, height);
 
             // get the data from canvas as 70% jpg (or specified type).
             return canvas.toDataURL(type, quality);


### PR DESCRIPTION
html5 canvas is not very good at downsampling jpegs, the output quality is very poor.
this improvement does a stepwise downsampling which greatly improves the image quality.

the method is discussed here: http://stackoverflow.com/questions/17861447/html5-canvas-drawimage-how-to-apply-antialiasing

self-explanatory example, downsized from 1920x1200:
![test-043](https://f.cloud.github.com/assets/1469382/2251163/4fd0526c-9d99-11e3-96e9-8c8c501a2282.jpg)
![test-044](https://f.cloud.github.com/assets/1469382/2251164/4fd59a1a-9d99-11e3-84c9-cdb5543e5c5c.jpg)
